### PR TITLE
Add Flathub link for TUHC

### DIFF
--- a/unofficial-homestuck-collection/index.html
+++ b/unofficial-homestuck-collection/index.html
@@ -100,6 +100,8 @@
       <br><br>
       <a class="anchorButton" href="https://github.com/Bambosh/unofficial-homestuck-collection/releases/download/2.0.5/The.Unofficial.Homestuck.Collection-2.0.5.AppImage" target="_blank"><i class="fab fa-linux"></i> Linux (.AppImage) - V2.0.5</a>
       <br><br>
+      <a class="anchorButton" href="https://flathub.org/apps/details/dev.bambosh.UnofficialHomestuckCollection" target="_blank"><i class="fab fa-linux"></i> Linux (Flatpak)</a>
+      <br><br>
       <a href="https://github.com/Bambosh/unofficial-homestuck-collection/releases" target="_blank">Full release history on GitHub</a>
       <br><br>
       <a href="old_versions.html" target="_blank">Previous Versions</a>


### PR DESCRIPTION
Adds a link to the Flatpak package of The Unofficial Homestuck Collection.